### PR TITLE
Fixing nil value errors

### DIFF
--- a/lua/citylights.lua
+++ b/lua/citylights.lua
@@ -20,7 +20,12 @@
 
 vim.g.colors_name = 'citylights'
 
-local Color, colors, Group, groups, styles = require('colorbuddy').setup()
+local colorbuddy = require('colorbuddy')
+local Color = colorbuddy.Color
+local colors = colorbuddy.colors
+local Group = colorbuddy.Group
+local groups = colorbuddy.groups
+local styles = colorbuddy.styles
 local none = colors.NONE
 local plain = styles.NONE
 local bold = styles.bold


### PR DESCRIPTION
Upon installing this plugin in NeoVim with VimPlug, nil value errors occured. Fixed this by changing how the parts of the colorbuddy package are imported.